### PR TITLE
Avoid infinite loop: signal handler modifies errno

### DIFF
--- a/lib/Sendmail/PMilter.pm
+++ b/lib/Sendmail/PMilter.pm
@@ -895,7 +895,7 @@ sub postfork_dispatcher () {
 
 		while (1) {
 			my $socket = $lsocket->accept();
-			next if $!{EINTR};
+			next if !$socket;
 
 			warn "$$: incoming connection\n" if ($DEBUG > 0);
 


### PR DESCRIPTION
The postfork_dispatcher relies on errno being EINTR when accept() gets interrupted by a signal (namely, sigchld here). However, the sigchld handler calls waitpid() which sets errno to ECHLD when no more child processes exist.
When the last child exits while the master is in accept(), accept() fails and errno is very likely to be ECHLD when checked. Previously, the handler proceeded as it does for real connections, forked a child process. That is likely to be the only child existing, terminating very soon (as there is no connection in fact), being reaped. The parent is likely accept()ing new connections, which brings us back to the beginning of the loop. This continues eating up a good part of the cpu, until one of the conditions named "likely" fails, which can take some minutes.
Proposed quick fix (this patch): do not rely on errno being EINTR, but simply go back to accept() in the parent when accept() did not return a socket.
