### PR TITLE
bug in Sendmail::PMilter

### DIFF
--- a/lib/Sendmail/PMilter/Context.pm
+++ b/lib/Sendmail/PMilter/Context.pm
@@ -469,7 +469,7 @@ sub getsymval ($$) {
 	my $this = shift;
 	my $key = shift;
 
-	foreach my $code (SMFIC_RCPT, SMFIC_MAIL, SMFIC_HELO, SMFIC_CONNECT) {
+	foreach my $code (SMFIC_RCPT, SMFIC_MAIL, SMFIC_HELO, SMFIC_CONNECT, SMFIC_HEADER) {
 		my $val = $this->{symbols}{$code}{$key};
 
 		return $val if defined($val);

--- a/lib/Sendmail/PMilter/Context.pm
+++ b/lib/Sendmail/PMilter/Context.pm
@@ -305,12 +305,7 @@ sub main ($) {
 
 	# XXX better error handling?  die here to let an eval further up get it?
 	if ($err) {
-		# completely unnecessary because at this point 'c' is already sent 
-		# by call_hooks() and socket is closed by MTA
-		#$this->write_packet(SMFIR_TEMPFAIL) if defined($socket);
 		warn $err;
-	#} else {
-		#$this->write_packet(SMFIR_CONTINUE) if defined($socket);
 	}
 
 	undef;

--- a/lib/Sendmail/PMilter/Context.pm
+++ b/lib/Sendmail/PMilter/Context.pm
@@ -305,10 +305,12 @@ sub main ($) {
 
 	# XXX better error handling?  die here to let an eval further up get it?
 	if ($err) {
-		$this->write_packet(SMFIR_TEMPFAIL) if defined($socket);
+		# completely unnecessary because at this point 'c' is already sent 
+		# by call_hooks() and socket is closed by MTA
+		#$this->write_packet(SMFIR_TEMPFAIL) if defined($socket);
 		warn $err;
-	} else {
-		$this->write_packet(SMFIR_CONTINUE) if defined($socket);
+	#} else {
+		#$this->write_packet(SMFIR_CONTINUE) if defined($socket);
 	}
 
 	undef;


### PR DESCRIPTION
fixed sending of double SMFIR_CONTINUE; using postfix / debian 6 / prefork_dispatcher it crashed the perl process. Dispatcher starts automatically new, thus it does not affect the functionality. Just 1 process processes 1 msg.
After fix one perl process handles max_requests_per_child messages before recycling.
